### PR TITLE
Extract CommentsController from TripsController

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,0 +1,58 @@
+class CommentsController < ApplicationController
+  before_action :set_trip
+
+  # GET /trips/:trip_id/comments
+  def index
+    comments =
+      HTTParty
+      .get("#{ENV["YT_COMMENT_API_URL"]}/trips/#{params[:id]}/comments")
+      .as_json["data"]
+
+    users = User.where(id: comments.map{|comm| comm["user_id"]})
+    users = custom_serializer(users, UserSerializer).as_json
+
+    comments = comments.map! do |comment|
+      comment.merge(user: users.find{|user| user[:id] == comment["user_id"].to_i})
+    end
+
+    render json: comments
+  end
+
+  # POST /trips/:trip_id/comments
+  def create
+    if comment_params[:user_id] == current_user.id
+      comment =
+        HTTParty
+        .post(
+          "#{ENV["YT_COMMENT_API_URL"]}/comments",
+          body: {
+            comment: comment_params.as_json
+        }).as_json["data"]
+
+      comment["user"] = custom_serializer([User.find(current_user.id)], UserSerializer).as_json[0]
+      broadcast(comment)
+      render json: comment
+    else
+      render json: "ERROR", status: :unauthorized
+    end
+  end
+
+  # DELETE /trips/:trip_id/comments/:id
+  def destroy
+    if params[:user_id] == current_user.id.to_s
+      HTTParty.delete("#{ENV["YT_COMMENT_API_URL"]}/comments/#{params[:id]}")
+    else
+      render json: "ERROR", status: :unauthorized
+    end
+  end
+
+  private
+
+  def set_trip
+    @trip = Trip.find params[:trip_id] || comment_params[:trip_id]
+  end
+
+  def comment_params
+    params.require(:comment).permit(:id, :user_id, :trip_id, :message)
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,24 +1,23 @@
 Rails.application.routes.draw do
   # get 'users/create'
 
-  # Made For Devise intergation 
+  # Made For Devise intergation
   # TODO: Should be changed to yatrums home index
   root to: "home#index"
-  
+
   devise_for :users
-  
+
   mount RailsAdmin::Engine => '/admin', as: 'rails_admin'
 
   get 'users/:user_id/trips', to: 'trips#get_user_trips'
   post 'trips/search', to: 'trips#search'
   post 'trips/like', to: 'trips#like'
   get 'trending/trips', to: 'trips#trending'
-  get 'trips/:id/comments', to: 'trips#comments'
-  post 'trips/comments', to: 'trips#delete_comment'
-  post 'trips/add_comments', to: 'trips#add_comment'
   post 'trips/increase_view_count', to: 'trips#increase_view_count'
   post 'graph_data_for_trip', to: 'trips#graph_data_for_trip'
-  resources :trips
+  resources :trips do
+    resources :comments, only: [:index, :create, :destroy]
+  end
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 
   post 'auth/:provider', to: 'authentication#social_authenticate'


### PR DESCRIPTION
It seems like everyone was sidetracked during calibration on the non-standardness of the TripsController, especially relating to Comments, and the routes around those.

I extracted a CommentsController and REST-ified the routes a bit to avoid some confusion.

(See https://github.com/woven-teams/yatrum/pull/1 for the parallel frontend changes.)